### PR TITLE
Cleanup on 20230308

### DIFF
--- a/mikado-app/src/pages/Graph/DisplayLayer.js
+++ b/mikado-app/src/pages/Graph/DisplayLayer.js
@@ -9,6 +9,7 @@ import { DEFAULT_EDGE_OPTIONS, EDGE_TYPES, NODE_TYPES } from "./graphTheme";
 import { MY_NODE_CONNECTION_MODE } from "./MyNode";
 import { DRAG_AND_DROP_EFFECT, DRAG_AND_DROP_MAGIC, DRAG_AND_DROP_MIME } from "./MyDrawer";
 import DisplayLayerHandle from "./DisplayLayerHandle";
+import createIntersectionDetectorFor from "../../viewmodel/aabb";
 
 /**
  * Remove the React Flow attribution temporarily so the demo looks cleaner.
@@ -64,14 +65,9 @@ function DisplayLayerInternal({ uid, notifySuccessElseError, setDisplayLayerHand
   }
 
   function onNodeDragStop(_, node) {
-    const { id, position: { x: l, y: t } } = node;
-    const r = l + node.width, b = t + node.height;
-    const target = nodes.find(other => {
-      const { x: oL, y: oT } = other.position;
-      const oR = oL + other.width, oB = oT + other.height;
-      return !(other.id === id || r < oL || l > oR || t > oB || b < oT);
-    });
+    const target = nodes.find(createIntersectionDetectorFor(node));
     if (target) {
+      const { id } = node;
       operations.restoreNodePosition(id);
       operations.connectOrDisconnect(id, target.id);
     }

--- a/mikado-app/src/pages/Graph/DisplayLayerHandle.js
+++ b/mikado-app/src/pages/Graph/DisplayLayerHandle.js
@@ -1,0 +1,40 @@
+/**
+ * Callback object for things like floating controls to interact with the viewmodel
+ */
+export default class DisplayLayerHandle {
+  /**
+   * The underlying DisplayLayerOperations.
+   * This is set to private to encapsulate the DisplayLayerOperations from the rest of the objects
+   */
+  #displayLayerOperations;
+
+  /**
+   * The id of the node selected in the graph
+   */
+  #selectedNodeId;
+
+  /**
+   * This object is to be recreated when anything relevant in the DisplayLayer changes.
+   * It can be set to undefined when the DisplayLayer is gone during transitions.
+   */
+  constructor(displayLayerOperations = void 0, selectedNodeId = void 0) {
+    this.#displayLayerOperations = displayLayerOperations;
+    this.#selectedNodeId = selectedNodeId;
+  }
+
+  /**
+   * Returns the display name of the selected node
+   */
+  getSelectedNodeName() {
+    const id = this.#selectedNodeId;
+    return id && this.#displayLayerOperations?.getNodeLabel(id);
+  }
+
+  /**
+   * Sets the display name of the selected node
+   */
+  setSelectedNodeName(name) {
+    const id = this.#selectedNodeId;
+    id && this.#displayLayerOperations?.setNodeLabel(id, name);
+  }
+}

--- a/mikado-app/src/pages/Graph/DisplayLayerHandle.js
+++ b/mikado-app/src/pages/Graph/DisplayLayerHandle.js
@@ -37,4 +37,12 @@ export default class DisplayLayerHandle {
     const id = this.#selectedNodeId;
     id && this.#displayLayerOperations?.setNodeLabel(id, name);
   }
+
+  /**
+   * Adds a node, preferentially in the centre of the screen
+   */
+  addNode() {
+    // TODO Pass the viewport center to the class constructor so it can be used here
+    this.#displayLayerOperations?.addNode({x: 0, y: 0});
+  }
 }

--- a/mikado-app/src/pages/Graph/MyDrawer.js
+++ b/mikado-app/src/pages/Graph/MyDrawer.js
@@ -11,15 +11,15 @@ function onDragStart(event) {
   event.dataTransfer.effectAllowed = DRAG_AND_DROP_EFFECT;
 }
 
-function MyDrawer({ selectionData }) {
+function MyDrawer({ displayLayerHandle }) {
   // TODO fix the swiping on desktop
   const ref = useRef();
   useEffect(() => {
     const { current } = ref;
-    if (current) {
-      current.value = selectionData.name;
-    }
-  }, [selectionData]);
+    current && (current.value = displayLayerHandle.getSelectedNodeName());
+  }, [displayLayerHandle]);
+  const selectedNodeName = displayLayerHandle.getSelectedNodeName();
+  console.log("snn", selectedNodeName);
   return <SwipeableDrawer
     open={true}
     onClose={() => void 0}
@@ -29,8 +29,8 @@ function MyDrawer({ selectionData }) {
     disableSwipeToOpen={false}
   >
     <div id="puller"></div>
-    {selectionData ?
-      <input ref={ref} onChange={e => selectionData.setName(e.target.value)} />
+    {typeof selectedNodeName === "string" ?
+      <input ref={ref} onChange={e => displayLayerHandle.setSelectedNodeName(e.target.value)} />
       :
       <div id="add-node-button" onDragStart={onDragStart} draggable>Add Node</div>
     }

--- a/mikado-app/src/pages/Graph/MyDrawer.js
+++ b/mikado-app/src/pages/Graph/MyDrawer.js
@@ -19,7 +19,6 @@ function MyDrawer({ displayLayerHandle }) {
     current && (current.value = displayLayerHandle.getSelectedNodeName());
   }, [displayLayerHandle]);
   const selectedNodeName = displayLayerHandle.getSelectedNodeName();
-  console.log("snn", selectedNodeName);
   return <SwipeableDrawer
     open={true}
     onClose={() => void 0}

--- a/mikado-app/src/pages/Graph/MyNode.js
+++ b/mikado-app/src/pages/Graph/MyNode.js
@@ -3,18 +3,20 @@ import useDisplayLayerStore from "../../viewmodel/displayLayerStore";
 
 export const MY_NODE_CONNECTION_MODE = ConnectionMode.Loose;
 
-const deleteNodeSelector = (state) => state.operations.deleteNode;
+const operationsSelector = (state) => state.operations;
 
 function MyNode({ id, data }) {
-  const deleteNode = useDisplayLayerStore(deleteNodeSelector);
+  const operations = useDisplayLayerStore(operationsSelector);
 
-  return <>
+  // TODO add node completion checkmark button
+  void operations.setNodeCompleted;
+  return <div className={data.completed ? "node-done" : "node-future"}>
     <NodeToolbar>
-      <button onClick={() => deleteNode(id)}>&#128465;</button>
+      <button onClick={() => operations.deleteNode(id)}>&#128465;</button>
     </NodeToolbar>
     {data.label}
     <Handle />
-  </>
+  </div>
 }
 
 export default MyNode;

--- a/mikado-app/src/pages/Graph/Plaza.css
+++ b/mikado-app/src/pages/Graph/Plaza.css
@@ -10,11 +10,33 @@ main {
 }
 
 .react-flow__node-default {
-  background: #f6ad55;
   border-radius: 2px;
   border: 1px solid transparent;
+}
+
+.react-flow__node-default > div {
   padding: 2px 5px;
   font-weight: 700;
+}
+
+.react-flow__node-default > div.node-future {
+  /*
+   * TODO
+   */
+  background: #f6ad55;
+}
+
+.react-flow__node-default > div.node-done {
+  /*
+   * TODO
+   */
+  background: #f6ad55;
+}
+
+.react-flow__node-default > div.node-ready {
+  /*
+   * TODO this is for the completion part 2
+   */
 }
 
 .react-flow__handle.source {

--- a/mikado-app/src/pages/Graph/Plaza.js
+++ b/mikado-app/src/pages/Graph/Plaza.js
@@ -3,6 +3,7 @@ import "./Plaza.css";
 import useSnackbar from "./MySnackbar";
 import MyDrawer from "./MyDrawer";
 import { useState } from "react";
+import DisplayLayerHandle from "./DisplayLayerHandle";
 
 /**
  * The Plaza component is the main page that users view and edit graphs.
@@ -17,12 +18,12 @@ function Plaza({ uid }) {
   const [snackbar, notifySuccessElseError] = useSnackbar();
   // Wires the active DisplayLayer to the bottom panel
   // Any inactive DisplayLayer can receive a noop callback
-  const [selectionData, setSelectionData] = useState(void 0);
+  const [displayLayerHandle, setDisplayLayerHandle] = useState(new DisplayLayerHandle());
 
   return <main>
-    <DisplayLayer key={uid} uid={uid} notifySuccessElseError={notifySuccessElseError} setSelectionData={setSelectionData} />
+    <DisplayLayer key={uid} uid={uid} notifySuccessElseError={notifySuccessElseError} setDisplayLayerHandle={setDisplayLayerHandle} />
     {snackbar}
-    <MyDrawer selectionData={selectionData} />
+    <MyDrawer displayLayerHandle={displayLayerHandle} />
   </main>
 }
 

--- a/mikado-app/src/viewmodel/aabb.js
+++ b/mikado-app/src/viewmodel/aabb.js
@@ -1,0 +1,20 @@
+/**
+ * Returns a function that returns true when another node intersects this one.
+ */
+export default function createIntersectionDetectorFor(nodeLike) {
+  // Convert this node's size offsets into absolute coordinates
+  const { id, position: { x: myLeft, y: myTop } } = nodeLike;
+  const myRight = myLeft + nodeLike.width, myBottom = myTop + nodeLike.height;
+  return other => {
+    // Convert other node's size offsets into absolute coordinates
+    const { x: otherLeft, y: otherTop } = other.position;
+    const otherRight = otherLeft + other.width, otherBottom = otherTop + other.height;
+    // To know when two nodes intersect, just consider the contrapositive
+    return !(other.id === id // Ignore self-intersection, or else it will always return true
+      || myRight < otherLeft // I'm to your right, with a vertical line between us
+      || myLeft > otherRight // I'm to your left, with a vertical line between us
+      || myTop > otherBottom // I'm below you, with a horizontal line between us
+      || myBottom < otherTop // I'm above you, with a horizontal line between us
+    );
+  };
+}

--- a/mikado-app/src/viewmodel/displayLayerStore.js
+++ b/mikado-app/src/viewmodel/displayLayerStore.js
@@ -306,9 +306,23 @@ class DisplayLayerOperations {
   }
 
   /**
+   * Returns the display name for a node
+   */
+  getNodeLabel(id) {
+    // This is only O(n) so no need to optimize
+    // Notably the drag operation is also at least O(n) so the user would notice that first
+    for (const node of this.#state.nodes) {
+      if (node.id === id) {
+        return node.data.label;
+      }
+    }
+    throw new Error();
+  }
+
+  /**
    * Changes the display name for a node
    */
-  renameNode(id, name) {
+  setNodeLabel(id, name) {
     this.#set({
       nodes: this.#state.nodes.map(
         node => node.id !== id ? node : { ...node, data: { ...node.data, label: name } },

--- a/mikado-app/src/viewmodel/displayLayerStore.js
+++ b/mikado-app/src/viewmodel/displayLayerStore.js
@@ -110,11 +110,6 @@ class DisplayLayerOperations {
    */
   #backwardConnections = {};
 
-  /**
-   * A scratch area for depth-first search.
-   */
-  #depthFirstSearch = {};
-
   // Zustand data
 
   /**
@@ -166,15 +161,6 @@ class DisplayLayerOperations {
     loadFromDb(uid).then(([nodes, edges, forwardConnections, backwardConnections]) => {
       this.#forwardConnections = forwardConnections;
       this.#backwardConnections = backwardConnections;
-
-      // Reset depthFirstSearch
-      const depthFirstSearch = {};
-      const autoincremented = generateAutoincremented();
-      for (const key in autoincremented) {
-        depthFirstSearch[key] = autoincremented;
-      }
-      this.#depthFirstSearch = depthFirstSearch;
-
       this.#set({ nodes, edges, loadAutoincremented: generateAutoincremented() });
       this.#loading = false;
     });
@@ -213,7 +199,6 @@ class DisplayLayerOperations {
     const id = generateAutoincremented().toString();
     this.#forwardConnections[id] = [];
     this.#backwardConnections[id] = [];
-    this.#depthFirstSearch[id] = id;
     this.#set({ nodes: [...nodes, createNodeObject(id, l, t)] });
   }
 
@@ -235,7 +220,6 @@ class DisplayLayerOperations {
     // Then delete the containers for this vertex
     delete forwardConnections[id];
     delete backwardConnections[id];
-    delete this.#depthFirstSearch[id];
 
     const { nodes, edges } = this.#state;
     this.#set({
@@ -282,7 +266,7 @@ class DisplayLayerOperations {
     } else if (!forwardConnections[srcId].includes(dstId)) { // No connection found
       // Check for cycles
       const autoincremented = generateAutoincremented();
-      const depthFirstSearch = this.#depthFirstSearch;
+      const depthFirstSearch = {};
 
       function dfs(otherId) {
         // Use autoincremented as a visited boolean

--- a/mikado-app/src/viewmodel/displayLayerStore.js
+++ b/mikado-app/src/viewmodel/displayLayerStore.js
@@ -183,7 +183,7 @@ class DisplayLayerOperations {
    */
   addNode(position) {
     const { nodes } = this.#state;
-    // Reject upon intersection
+    // Avoid intersections
     if (nodes.some(createIntersectionDetectorFor({
       id: void 0,
       position,
@@ -192,6 +192,7 @@ class DisplayLayerOperations {
       width: 100,
       height: 60,
     }))) {
+      // TODO Better UX is to find a free spot instead of silently failing
       return;
     }
     // Allocate everything

--- a/mikado-app/src/viewmodel/displayLayerStore.js
+++ b/mikado-app/src/viewmodel/displayLayerStore.js
@@ -2,6 +2,7 @@ import { create } from "zustand";
 import { loadFromDb, saveToDb } from "./serde";
 import generateAutoincremented from "./autoincrement";
 import { createEdgeObject, createNodeObject } from "./displayObjectFactory";
+import createIntersectionDetectorFor from "./aabb";
 
 /**
  * Subset of React Flow's onNodesChange.
@@ -183,15 +184,14 @@ class DisplayLayerOperations {
   addNode(position) {
     const { nodes } = this.#state;
     // Reject upon intersection
-    // Too bad it's not possible to know the dimensions of the current node to be added
-    // So we will just hardcode some kind of size
-    const { x: l, y: t } = position;
-    const r = l + 100, b = t + 60;
-    if (nodes.some(other => {
-      const { x: oL, y: oT } = other.position;
-      const oR = oL + other.width, oB = oT + other.height;
-      return !(r < oL || l > oR || t > oB || b < oT);
-    })) {
+    if (nodes.some(createIntersectionDetectorFor({
+      id: void 0,
+      position,
+      // Too bad it's not possible to know the dimensions of the current node to be added
+      // So we will just hardcode some kind of size
+      width: 100,
+      height: 60,
+    }))) {
       console.log("dup");
       return;
     }
@@ -199,7 +199,7 @@ class DisplayLayerOperations {
     const id = generateAutoincremented().toString();
     this.#forwardConnections[id] = [];
     this.#backwardConnections[id] = [];
-    this.#set({ nodes: [...nodes, createNodeObject(id, l, t)] });
+    this.#set({ nodes: [...nodes, createNodeObject(id, position.x, position.y)] });
   }
 
   /**

--- a/mikado-app/src/viewmodel/displayLayerStore.js
+++ b/mikado-app/src/viewmodel/displayLayerStore.js
@@ -192,7 +192,6 @@ class DisplayLayerOperations {
       width: 100,
       height: 60,
     }))) {
-      console.log("dup");
       return;
     }
     // Allocate everything
@@ -208,8 +207,6 @@ class DisplayLayerOperations {
   deleteNode(id) {
     const forwardConnections = this.#forwardConnections;
     const backwardConnections = this.#backwardConnections;
-    console.log(JSON.stringify(forwardConnections), JSON.stringify(backwardConnections));
-
     // Unlink everything touching this
     for (const connection of backwardConnections[id]) {
       arrayRemoveByValueIfPresent(forwardConnections[connection], id);
@@ -226,7 +223,6 @@ class DisplayLayerOperations {
       nodes: nodes.filter(node => node.id !== id),
       edges: edges.filter(edge => edge.source !== id && edge.target !== id),
     });
-    console.log(JSON.stringify(forwardConnections), JSON.stringify(backwardConnections));
   }
 
   /**

--- a/mikado-app/src/viewmodel/displayLayerStore.js
+++ b/mikado-app/src/viewmodel/displayLayerStore.js
@@ -326,6 +326,14 @@ class DisplayLayerOperations {
       ),
     });
   }
+
+  /**
+   * Sets whether the specified node is completed.
+   * This also updates the highlighting of nodes without outstanding dependencies.
+   */
+  setNodeCompleted(id, completed) {
+    // TODO
+  }
 }
 
 const useDisplayLayerStore = create((set, get) => ({

--- a/mikado-app/src/viewmodel/displayLayerStore.js
+++ b/mikado-app/src/viewmodel/displayLayerStore.js
@@ -3,6 +3,11 @@ import { loadFromDb, saveToDb } from "./serde";
 import generateAutoincremented from "./autoincrement";
 import { createEdgeObject, createNodeObject } from "./displayObjectFactory";
 
+/**
+ * Subset of React Flow's onNodesChange.
+ * This is to filter the changes so that of the user's requested changes,
+ * only changes we can handle are realized.
+ */
 function myOnNodesChange(changes, nodes, set) {
   const changesById = {};
   let affected = false;
@@ -65,210 +70,280 @@ function arrayRemoveByValueIfPresent(array, value) {
   }
 }
 
+/**
+ * Separate object for functions and cache for the viewmodel.
+ *
+ * Its fields are modified directly to avoid getting in the way of the shallow comparison.
+ * It is also here to skip shallow compare of all those methods.
+ */
+class DisplayLayerOperations {
+  /*
+   * DisplayLayer cache data.
+   * This data contains caches so that computations can be efficiently performed before
+   * passing them to the View (React Flow).
+   */
+
+  /**
+   * A loading indicator.
+   *
+   * React sometimes likes to run useEffect twice, so this variable must be assigned directly and immediately.
+   * This also helps with preventing other race conditions.
+   */
+  #loading = false;
+
+  /**
+   * The forwards connection map of arrays of IDs.
+   *
+   * This duplicates the edges data, but is in a format easier to manipulate. It will also be the version
+   * stored in the database. The forward connections are used for depth-first search and updating
+   * node completion.
+   *
+   * These arrays are not sorted. On one hand this allows fast insertion. On the other hand query is O(n).
+   * But in practice linear scans are quite fast or even faster due to CPU caching / branch prediction.
+   */
+  #forwardConnections = {};
+
+  /**
+   * Similar to forwardConnections.
+   *
+   * Used mainly for deletion.
+   */
+  #backwardConnections = {};
+
+  /**
+   * A scratch area for depth-first search.
+   */
+  #depthFirstSearch = {};
+
+  // Zustand data
+
+  /**
+   * Sets the Zustand store state
+   */
+  #set;
+
+  /**
+   * Gets the Zustand store state
+   */
+  #get;
+
+  /**
+   * Cached state after getting
+   */
+  #state;
+
+  constructor(set, get) {
+    this.#set = set;
+    this.#state = (this.#get = get)();
+    const prototype = Object.getPrototypeOf(this);
+    for (const name of Object.getOwnPropertyNames(prototype)) {
+      if (name === "constructor") continue;
+      // Patch all methods to reload the state from the store
+      // This is equivalent to putting a decorator in front of each method
+      const wrapped = prototype[name];
+      this[name] = (...args) => {
+        // Refresh the cached state
+        this.#state = this.#get();
+        if (this.#loading) return; // Ignore everything while loading
+        // Call function normally, while also binding it
+        return wrapped.apply(this, args);
+      };
+    }
+  }
+
+  /**
+   * Processes changes from React Flow
+   */
+  onNodesChange(changes) {
+    myOnNodesChange(changes, this.#state.nodes, this.#set);
+  }
+
+  /**
+   * Loads this layer from the database
+   */
+  load(uid) {
+    this.#loading = true;
+    loadFromDb(uid).then(([nodes, edges, forwardConnections, backwardConnections]) => {
+      this.#forwardConnections = forwardConnections;
+      this.#backwardConnections = backwardConnections;
+
+      // Reset depthFirstSearch
+      const depthFirstSearch = {};
+      const autoincremented = generateAutoincremented();
+      for (const key in autoincremented) {
+        depthFirstSearch[key] = autoincremented;
+      }
+      this.#depthFirstSearch = depthFirstSearch;
+
+      this.#set({ nodes, edges, loadAutoincremented: generateAutoincremented() });
+      this.#loading = false;
+    });
+  }
+
+  /**
+   * Saves this layer to the database
+   */
+  save(uid, notifySuccessElseError) {
+    this.#loading = true;
+    saveToDb(this.#state.nodes, this.#forwardConnections, uid).then(x => {
+      this.#loading = false;
+      notifySuccessElseError(x);
+    });
+  }
+
+  /**
+   * Inserts a new node
+   */
+  addNode(position) {
+    const { nodes } = this.#state;
+    // Reject upon intersection
+    // Too bad it's not possible to know the dimensions of the current node to be added
+    // So we will just hardcode some kind of size
+    const { x: l, y: t } = position;
+    const r = l + 100, b = t + 60;
+    if (nodes.some(other => {
+      const { x: oL, y: oT } = other.position;
+      const oR = oL + other.width, oB = oT + other.height;
+      return !(r < oL || l > oR || t > oB || b < oT);
+    })) {
+      console.log("dup");
+      return;
+    }
+    // Allocate everything
+    const id = generateAutoincremented().toString();
+    this.#forwardConnections[id] = [];
+    this.#backwardConnections[id] = [];
+    this.#depthFirstSearch[id] = id;
+    this.#set({ nodes: [...nodes, createNodeObject(id, l, t)] });
+  }
+
+  /**
+   * Removes a node
+   */
+  deleteNode(id) {
+    const forwardConnections = this.#forwardConnections;
+    const backwardConnections = this.#backwardConnections;
+    console.log(JSON.stringify(forwardConnections), JSON.stringify(backwardConnections));
+
+    // Unlink everything touching this
+    for (const connection of backwardConnections[id]) {
+      arrayRemoveByValueIfPresent(forwardConnections[connection], id);
+    }
+    for (const connection of forwardConnections[id]) {
+      arrayRemoveByValueIfPresent(backwardConnections[connection], id);
+    }
+    // Then delete the containers for this vertex
+    delete forwardConnections[id];
+    delete backwardConnections[id];
+    delete this.#depthFirstSearch[id];
+
+    const { nodes, edges } = this.#state;
+    this.#set({
+      nodes: nodes.filter(node => node.id !== id),
+      edges: edges.filter(edge => edge.source !== id && edge.target !== id),
+    });
+    console.log(JSON.stringify(forwardConnections), JSON.stringify(backwardConnections));
+  }
+
+  /**
+   * Saves the position of the node
+   */
+  markNodePosition(id) {
+    this.#set({
+      nodes: this.#state.nodes.map(
+        node => node.id !== id ? node : { ...node, data: { ...node.data, savedPosition: node.position } },
+      )
+    });
+  }
+
+  /**
+   * Moves the node back to the saved position
+   */
+  restoreNodePosition(id) {
+    this.#set({
+      nodes: this.#state.nodes.map(node => {
+        if (node.id !== id) return node;
+        const { savedPosition } = node.data;
+        return !savedPosition ? node : { ...node, position: savedPosition };
+      }),
+    });
+  }
+
+  /**
+   * Connects or disconnects two nodes
+   */
+  connectOrDisconnect(srcId, dstId) {
+    const forwardConnections = this.#forwardConnections;
+    const backwardConnections = this.#backwardConnections;
+    if (forwardConnections[dstId].includes(srcId)) { // Backward connection found
+      const tmp = dstId;
+      dstId = srcId;
+      srcId = tmp;
+    } else if (!forwardConnections[srcId].includes(dstId)) { // No connection found
+      // Check for cycles
+      const autoincremented = generateAutoincremented();
+      const depthFirstSearch = this.#depthFirstSearch;
+
+      function dfs(otherId) {
+        // Use autoincremented as a visited boolean
+        if (depthFirstSearch[otherId] === autoincremented) return;
+        depthFirstSearch[otherId] = autoincremented;
+        // An invariant, somewhat related to induction, is that
+        // the graph does not previously contain cycles.
+        // Therefore, any newly added cycle must involve the newly added
+        // node, so we only need to check if that is involved in any loop
+        for (const connection of forwardConnections[otherId]) {
+          // Use exceptions to unwind quickly
+          if (connection === srcId) throw new Error();
+          dfs(connection);
+        }
+      }
+
+      try {
+        dfs(dstId);
+      } catch (_) {
+        // Cycle detected, don't add edge
+        return;
+      }
+      forwardConnections[srcId].push(dstId);
+      backwardConnections[dstId].push(srcId);
+      this.#set({ edges: [...this.#state.edges, createEdgeObject(srcId, dstId)] });
+      return;
+    } // else forward connection found, so will delete it
+    const forward = forwardConnections[srcId];
+    const backward = backwardConnections[dstId];
+    forward.splice(forward.indexOf(dstId), 1);
+    backward.splice(backward.indexOf(srcId), 1);
+    this.#set({
+      edges: this.#state.edges.filter(
+        edge => edge.source !== srcId || edge.target !== dstId,
+      ),
+    });
+  }
+
+  /**
+   * Changes the display name for a node
+   */
+  renameNode(id, name) {
+    this.#set({
+      nodes: this.#state.nodes.map(
+        node => node.id !== id ? node : { ...node, data: { ...node.data, label: name } },
+      ),
+    });
+  }
+}
+
 const useDisplayLayerStore = create((set, get) => ({
   nodes: [],
   edges: [],
   /**
-   * Internal object modified directly, and avoids getting in the way of the shallow comparison.
-   */
-  _internal: {
-    /**
-     * A loading indicator.
-     *
-     * React sometimes likes to run useEffect twice, so this variable must be assigned directly and immediately.
-     * This also helps with preventing other race conditions.
-     */
-    loading: false,
-    /**
-     * The forwards connection map of arrays of IDs.
-     *
-     * This duplicates the edges data, but is in a format easier to manipulate. It will also be the version
-     * stored in the database. The forward connections are used for depth-first search and updating
-     * node completion.
-     *
-     * These arrays are not sorted. On one hand this allows fast insertion. On the other hand query is O(n).
-     * But in practice linear scans are quite fast or even faster due to CPU caching / branch prediction.
-     */
-    forwardConnections: {},
-    /**
-     * Similar to forwardConnections.
-     *
-     * Used mainly for deletion.
-     */
-    backwardConnections: {},
-    /**
-     * A scratch area for depth-first search.
-     */
-    depthFirstSearch: {},
-  },
-  /**
-   * Set to a new value on load. This is used passing a callback to load() runs too early.
+   * Set to a new value on load. This is used as passing a callback to load() runs too early.
    */
   loadAutoincremented: generateAutoincremented(),
   /**
-   * Separate object to skip shallow compare of all those methods.
+   * The actual operations
    */
-  operations: {
-    onNodesChange(changes) {
-      const state = get();
-      if (state._internal.loading) return;
-      myOnNodesChange(changes, state.nodes, set);
-    },
-    load(uid) {
-      const { _internal } = get();
-      if (_internal.loading) return;
-      _internal.loading = true;
-      loadFromDb(uid).then(([nodes, edges, forwardConnections, backwardConnections]) => {
-        _internal.forwardConnections = forwardConnections;
-        _internal.backwardConnections = backwardConnections;
-
-        // Reset depthFirstSearch
-        const depthFirstSearch = {};
-        const autoincremented = generateAutoincremented();
-        for (const key in autoincremented) {
-          depthFirstSearch[key] = autoincremented;
-        }
-        _internal.depthFirstSearch = depthFirstSearch;
-
-        set({ nodes, edges, loadAutoincremented: generateAutoincremented() });
-        _internal.loading = false;
-      });
-    },
-    save(uid, notifySuccessElseError) {
-      const { nodes, _internal } = get();
-      if (_internal.loading) return;
-      _internal.loading = true;
-      saveToDb(nodes, _internal.forwardConnections, uid).then(x => {
-        _internal.loading = false;
-        notifySuccessElseError(x);
-      });
-    },
-    addNode(position) {
-      const { nodes, _internal } = get();
-      if (_internal.loading) return;
-
-      // Reject upon intersection
-      // Too bad it's not possible to know the dimensions of the current node to be added
-      // So we will just hardcode some kind of size
-      const { x: l, y: t } = position;
-      const r = l + 100, b = t + 60;
-      if (nodes.some(other => {
-        const { x: oL, y: oT } = other.position;
-        const oR = oL + other.width, oB = oT + other.height;
-        return !(r < oL || l > oR || t > oB || b < oT);
-      })) {
-        console.log("dup");
-        return;
-      }
-
-      // Allocate everything
-      const id = generateAutoincremented().toString();
-      _internal.forwardConnections[id] = [];
-      _internal.backwardConnections[id] = [];
-      _internal.depthFirstSearch[id] = id;
-      set({ nodes: [...nodes, createNodeObject(id, l, t)] });
-    },
-    deleteNode(id) {
-      const { nodes, edges, _internal: { loading, forwardConnections, backwardConnections, depthFirstSearch } } = get();
-      if (loading) return;
-      console.log(JSON.stringify(forwardConnections), JSON.stringify(backwardConnections));
-
-      // Unlink everything touching this
-      for (const connection of backwardConnections[id]) {
-        arrayRemoveByValueIfPresent(forwardConnections[connection], id);
-      }
-      for (const connection of forwardConnections[id]) {
-        arrayRemoveByValueIfPresent(backwardConnections[connection], id);
-      }
-      // Then delete the containers for this vertex
-      delete forwardConnections[id];
-      delete backwardConnections[id];
-      delete depthFirstSearch[id];
-
-      set({
-        nodes: nodes.filter(node => node.id !== id),
-        edges: edges.filter(edge => edge.source !== id && edge.target !== id),
-      });
-      console.log(JSON.stringify(forwardConnections), JSON.stringify(backwardConnections));
-    },
-    /**
-     * Saves the position of the node.
-     */
-    markNodePosition(id) {
-      const { nodes, _internal } = get();
-      if (_internal.loading) return;
-      set({
-        nodes: nodes.map(node => node.id !== id ? node : { ...node, data: { ...node.data, savedPosition: node.position } }),
-      });
-    },
-    /**
-     * Moves the node back to the saved position.
-     */
-    restoreNodePosition(id) {
-      const { nodes, _internal } = get();
-      if (_internal.loading) return;
-      set({
-        nodes: nodes.map(node => {
-          if (node.id !== id) return node;
-          const { savedPosition } = node.data;
-          return !savedPosition ? node : { ...node, position: savedPosition };
-        }),
-      });
-    },
-    /**
-     * Connects or disconnects two nodes.
-     */
-    connectOrDisconnect(srcId, dstId) {
-      const { edges, _internal: { loading, forwardConnections, backwardConnections, depthFirstSearch } } = get();
-      if (loading) return;
-      if (forwardConnections[dstId].includes(srcId)) {
-        // Backward connection found
-        const tmp = dstId;
-        dstId = srcId;
-        srcId = tmp;
-      } else if (!forwardConnections[srcId].includes(dstId)) {
-        // No connection found
-
-        // Check for cycles
-        const autoincremented = generateAutoincremented();
-        const dfs = (otherId) => {
-          // Use autoincremented as a visited boolean
-          if (depthFirstSearch[otherId] === autoincremented) return;
-          depthFirstSearch[otherId] = autoincremented;
-          // An invariant, somewhat related to induction, is that
-          // the graph does not previously contain cycles.
-          // Therefore, any newly added cycle must involve the newly added
-          // node, so we only need to check if that is involved in any loop
-          for (const connection of forwardConnections[otherId]) {
-            // Use exceptions to unwind quickly
-            if (connection === srcId) throw new Error();
-            dfs(connection);
-          }
-        };
-        try {
-          dfs(dstId);
-        } catch (_) {
-          // Cycle detected, don't add edge
-          return;
-        }
-
-        forwardConnections[srcId].push(dstId);
-        backwardConnections[dstId].push(srcId);
-        set({ edges: [...edges, createEdgeObject(srcId, dstId)] });
-        return;
-      } // else forward connection found
-      const forward = forwardConnections[srcId];
-      const backward = backwardConnections[dstId];
-      forward.splice(forward.indexOf(dstId), 1);
-      backward.splice(backward.indexOf(srcId), 1);
-      set({ edges: edges.filter(edge => edge.source !== srcId || edge.target !== dstId) });
-    },
-    renameNode(id, name) {
-      const { nodes, _internal } = get();
-      if (_internal.loading) return;
-      set({ nodes: nodes.map(node => node.id !== id ? node : { ...node, data: { ...node.data, label: name } }) });
-    },
-  }
+  operations: new DisplayLayerOperations(set, get),
 }));
 
 export default useDisplayLayerStore;

--- a/mikado-app/src/viewmodel/displayObjectFactory.js
+++ b/mikado-app/src/viewmodel/displayObjectFactory.js
@@ -1,8 +1,9 @@
-export function createNodeObject(id, x, y, label = "New Node") {
+export function createNodeObject(id, x, y, label = "New Node", completed = false) {
+  // Not using React Flow's className as that may lead to maintainability problems
   return  {
     id,
     position: { x, y },
-    data: { label },
+    data: { label, completed },
   };
 }
 

--- a/mikado-app/src/viewmodel/serde.js
+++ b/mikado-app/src/viewmodel/serde.js
@@ -61,7 +61,8 @@ export async function loadFromDb(uid) {
     databaseKeysToNewIdsLookup[key] = id;
     forwardConnections[id] = [];
     backwardConnections[id] = []
-    return createNodeObject(id, +x, +y, label.toString());
+    const completed = false; // TODO
+    return createNodeObject(id, +x, +y, label.toString(), completed);
   });
 
   // Load edges from db
@@ -121,6 +122,7 @@ export function saveToDb(nodes, forwardConnections, uid) {
     newIdsToDatabaseKeysLookup[node.id] = index;
     // No need to coerce as we own node.data: T for Node<T>
     node_names[index] = node.data.label;
+    void node.data.completed; // TODO
     // Assuming there is no reason React Flow will change away from { x: number, y: number }
     positions[index] = node.position;
   });


### PR DESCRIPTION
This PR addresses feedback discussed in the chat, and prepares for the next sprint:
- Explain the axis aligned bounding box logic
- Simplify the depthFirstSearch property into a local
- Remove some leftover debugging
- Put the viewmodel operations in a class for readability, and move the cache variables there as well
- Generalize the `DisplayLayer` to `MyDrawer` callback into a proper `DisplayLayerHandle` class
- Add stubs to allow multiple people to work on things at the same time
  - Add add note button stubs
  - Add completion feature stubs, mostly for part 1