### PR TITLE
Remove default graph

### DIFF
--- a/firebase/firestore.rules
+++ b/firebase/firestore.rules
@@ -3,7 +3,6 @@ service cloud.firestore {
   match /databases/{database}/documents {
     match /{collectionName}/{doc} {
       allow read, write: if collectionName == request.auth.uid;
-      allow read: if collectionName == 'user-1';
     }
   }
 }

--- a/mikado-app/src/viewmodel/serde.js
+++ b/mikado-app/src/viewmodel/serde.js
@@ -1,6 +1,5 @@
 import { connectFirestoreEmulator, doc, getDoc, getFirestore, setDoc } from "firebase/firestore";
 import { firebase, USING_DEBUG_EMULATORS } from '../firebase';
-import { runtime_assert } from "./assert";
 import generateAutoincremented from "./autoincrement";
 import { createEdgeObject, createNodeObject } from "./displayObjectFactory";
 
@@ -10,20 +9,6 @@ if (USING_DEBUG_EMULATORS) {
 }
 
 /**
- * The default Mikado to open.
- *
- * For now this default graph is the only graph available until saving/multiple different files/documents is implemented.
- * Also, there is only one layer of the graph available until the subtrees feature is implemented.
- */
-// eslint-disable-next-line no-unused-vars
-var DEFAULT_GRAPH_ID = "graph-1";
-
-/**
- * A fallback "user account" to grab initial data from to introduce the user with.
- */
-const FALLBACK_TEMPLATE_USER_ID = "user-1";
-
-/**
  * Loads the nodes and edges from the database.
  */
 export async function loadFromDb(uid, graphName) {
@@ -31,11 +16,8 @@ export async function loadFromDb(uid, graphName) {
   let docSnap = await getDoc(doc(db, uid, graphName));
 
   if (!docSnap.exists()) {
-    // Grab fallback graph
-    docSnap = await getDoc(doc(db, FALLBACK_TEMPLATE_USER_ID, DEFAULT_GRAPH_ID));
+    return [[], [], {}, {}]
   }
-
-  runtime_assert(docSnap.exists());
 
   // TODO add a version key and prevent loading newer schemas
   const { node_names, positions, connections } = docSnap.data();


### PR DESCRIPTION
Closes #98.

There is a strange thing where the first node created will be in the center, not the top left corner like all subsequent nodes. This is probably the existing behavior for manually emptied graphs too. It can be fixed later, but this removal should be done to prepare for the database changes.

# Before

![image](https://user-images.githubusercontent.com/25646384/226786670-82cbb5ab-da2b-484f-b13a-443f2eb93671.png)

# After

![image](https://user-images.githubusercontent.com/25646384/226786538-fcb572fb-51db-4c99-bb74-2931635f04ff.png)

![image](https://user-images.githubusercontent.com/25646384/226786577-f5e1f160-796f-4e01-8766-fdd837b00d0d.png)

![image](https://user-images.githubusercontent.com/25646384/226786608-74b3be47-d4f6-419e-bd20-baf6f08a90a9.png)
