### PR TITLE
Add license

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,11 @@ More to come later.
 | [Project Management Gantt Chart](https://uottawa-my.sharepoint.com/personal/dqiao100_uottawa_ca/_layouts/15/guestaccess.aspx?docid=07b4afb81ea1b485dbaec7906683c5016&authkey=AVBAN_1w6hmBHhqfMNYwbdc&e=glD2qx) | Gantt chart for tracking tasks and planning over time |
 | [Formal Time Sheet](https://uottawa-my.sharepoint.com/personal/dqiao100_uottawa_ca/_layouts/15/guestaccess.aspx?docid=0290cd280943547d2b1fbee27c9330d13&authkey=AUHJjRQIY8Rv-EkD2LFu7u4&e=mEpMRc) | Time tracking |
 
+## License
 
+See the license [here](mikado-app/public/LICENSE.txt). The license applies to all files in this repository unless stated otherwise.
+
+This project is currently intended to be visible-source and not open-contribution like SQLite. This is currently in place to make it possible for our professor to evaluate our team project without outside interference. Derivative works are strongly discouraged, and the license will automatically assign us more rights than it gives you. At the end of 2023, we may decide to release it as open-source with/without a premium version. In the meantime, early testers are welcome to play with the beta version hosted on the cloud, though major breaking changing may occur regularly, including those affecting data.
 
 ## References
 

--- a/mikado-app/public/LICENSE.txt
+++ b/mikado-app/public/LICENSE.txt
@@ -1,0 +1,7 @@
+Copyright (c) 2023 Mikado developers
+
+1. VIP includes the people involved with this capstone project: Matthew Joseph Demczyk, Andriy Drozdyuk, Philippe Gagné, Daanish Khan, Timothy Lethbridge, Jodi Qiao, Daniel Tang, Peter Yoon.
+2. The author of a derivative work agrees to grant a `SPDX-License-Identifier: AGPL-3.0-or-later` license to everyone once at the same time they communicate that work to anyone.
+3. At the same time, whether or not they are a VIP or communicating it to a VIP, they agree to simultaneously grant a `SPDX-License-Identifier: MIT OR Apache-2.0` to all the VIPs
+4. The conditions in this file apply until it is deleted, in which case previous grants survive and it becomes possible to choose specifically which of the contained granted licenses to use
+5. For the avoidance of doubt, the adding of this file creates a derivative work, which relicenses the whole repository under this license


### PR DESCRIPTION
This adds a license as discussed during the call. This properly clarifies the licensing situation. The terms were chosen to grant us more rights than strangers during capstone so evaluation is not interfered with.