### PR TITLE
fix: node text color on ios/apple browsers

### DIFF
--- a/mikado-app/src/pages/Graph/Plaza.css
+++ b/mikado-app/src/pages/Graph/Plaza.css
@@ -84,7 +84,9 @@ main > main {
   background: none;
   border: none;
   border-bottom: 1px solid dimgrey;
-  color: initial;
+  /* color: initial; this turns input text font grey on Apple devices, -webkit-text-fill-color is the workaround*/ 
+  -webkit-text-fill-color: rgba(0, 0, 0, 1); 
+  color: rgba(0, 0, 0, 1);
   outline: none;
   padding: 0;
   text-overflow: ellipsis;


### PR DESCRIPTION
Because of Apple's [special magic with CSS font colours](https://stackoverflow.com/questions/21400182/safari-css-font-color-issue) we are using the -webkit-text-fill-color CSS property to make the node texts on Apple appear black to match its look on Chrome.