### PR TITLE
feat (#129): Allow text wrapping

### DIFF
--- a/mikado-app/src/pages/Graph/DisplayLayer.js
+++ b/mikado-app/src/pages/Graph/DisplayLayer.js
@@ -35,7 +35,7 @@ const notifyExportError = notifyError.bind(null, "There was an error exporting t
  */
 function DisplayLayerInternal({ uid, graph }) {
   const reactFlowWrapper = useRef(void 0);
-  const { nodes, edges, operations, editNode } = useStoreHack()(selector, shallow);
+  const { nodes, edges, operations, editNode, editingNodeId } = useStoreHack()(selector, shallow);
   const { project, fitView } = useReactFlow();
   const selectedNodeId = useRef(void 0);
 
@@ -180,6 +180,8 @@ function DisplayLayerInternal({ uid, graph }) {
       edges={edges}
       onNodesChange={operations.onNodesChange}
       nodesConnectable={false}
+      nodesDraggable={!editingNodeId}
+      panOnDrag={!editingNodeId}
       proOptions={proOptions}
       defaultEdgeOptions={DEFAULT_EDGE_OPTIONS}
       nodeTypes={NODE_TYPES}

--- a/mikado-app/src/pages/Graph/NodeLabel.js
+++ b/mikado-app/src/pages/Graph/NodeLabel.js
@@ -19,6 +19,14 @@ export default function NodeLabel({ id, label }) {
       ref.current?.select();
     }
   }, [editing]);
+  useEffect(() => {
+    const { current } = ref;
+    if (!current) return;
+    const { style } = current;
+    // Shrink and grow based on content
+    style.height = 0;
+    style.height = current.scrollHeight + "px";
+  }, [text]);
   if (!editing && text !== label) {
     setText(label);
   }
@@ -28,11 +36,13 @@ export default function NodeLabel({ id, label }) {
     operations.setNodeLabel(id, filteredText);
     setText(filteredText);
   }
-  return <input
-    type="text"
+  // <input> is single link
+  // <div contenteditable> is an accessibility and security problem
+  return <textarea
     autoFocus={editing}
     disabled={!editing}
     value={text}
+    rows={1}
     onChange={(e) => {setText(e.target.value)}}
     onKeyDown={(e) => {
       // Don't break IMEs

--- a/mikado-app/src/pages/Graph/NodeLabel.js
+++ b/mikado-app/src/pages/Graph/NodeLabel.js
@@ -10,6 +10,7 @@ export default function NodeLabel({ id, label }) {
   const {editingNodeId, editingNodeInitialValue, editNode, operations} = useStoreHack()(selector);
   const [text, setText] = useState(label);
   const ref = useRef(void 0);
+  const wasComposingRef = useRef(false);
   const editing = editingNodeId === id;
   useEffect(() => {
     if (editing) {
@@ -23,7 +24,9 @@ export default function NodeLabel({ id, label }) {
   }
   function finishEditing() {
     editNode("", "");
-    operations.setNodeLabel(id, text);
+    const filteredText = text.replaceAll('\n', ' ');
+    operations.setNodeLabel(id, filteredText);
+    setText(filteredText);
   }
   return <input
     type="text"
@@ -31,8 +34,13 @@ export default function NodeLabel({ id, label }) {
     disabled={!editing}
     value={text}
     onChange={(e) => {setText(e.target.value)}}
+    onKeyDown={(e) => {
+      // Don't break IMEs
+      wasComposingRef.current = e.nativeEvent.isComposing;
+    }}
     onKeyUp={(e) => {
       if (e.key !== "Enter") return;
+      if (wasComposingRef.current) return;
       finishEditing();
     }}
     onBlur={finishEditing}

--- a/mikado-app/src/pages/Graph/Plaza.css
+++ b/mikado-app/src/pages/Graph/Plaza.css
@@ -74,22 +74,23 @@ main > main {
   top: 5px;
 }
 
-.react-flow__node input {
+.react-flow__node textarea {
   appearance: none;
   background: none;
   border: none;
-  border-bottom: 1px solid dimgrey;
-  /* color: initial; this turns input text font grey on Apple devices, -webkit-text-fill-color is the workaround*/ 
-  -webkit-text-fill-color: rgba(0, 0, 0, 1); 
+  /* outline is all 4 sides, and border makes the element grow by 1 pixel when editing */
+  box-shadow: 0 1px 0 dimgrey;
+  /* color: initial; this turns input text font grey on Apple devices, -webkit-text-fill-color is the workaround*/
+  -webkit-text-fill-color: rgba(0, 0, 0, 1);
   color: rgba(0, 0, 0, 1);
   outline: none;
   padding: 0;
-  text-overflow: ellipsis;
+  resize: none;
   width: 100%;
 
   &:disabled {
     pointer-events: none;
-    border-bottom: none;
+    box-shadow: none;
   }
 }
 


### PR DESCRIPTION
Closes #129.

This implements text wrapping. The nodes can now wrap text onto multiple lines, but manual newlines are still filtered out as discussed.