### PR TITLE
feat (#85): Edit the graph name

### DIFF
--- a/firebase/firestore.rules
+++ b/firebase/firestore.rules
@@ -3,10 +3,12 @@ service cloud.firestore {
   match /databases/{database}/documents {
     match /{collectionName}/{doc} {
       allow read, write: if collectionName == request.auth.uid;
-      allow read: if collectionName == 'user-1';
       match /{collection=**} {
       	allow read, write: if request.auth != null;
       }
+    }
+    match /user/{uid}/graphs/{graph} {
+      allow read, write: if uid == request.auth.uid;
     }
   }
 }

--- a/mikado-app/src/components/MyAppBar/MyAppBar.css
+++ b/mikado-app/src/components/MyAppBar/MyAppBar.css
@@ -1,0 +1,14 @@
+div.MuiToolbar-root > input.seamless-editor {
+  -webkit-text-fill-color: #fff;
+  color: #fff;
+  font-size: 16pt;
+  font-family: monospace;
+  font-weight: 700;
+  letter-spacing: .3rem;
+  text-align: center;
+  box-shadow: 0 1px 0 lightgrey;
+
+  &:disabled {
+    box-shadow: none;
+  }
+}

--- a/mikado-app/src/components/MyAppBar/MyAppBar.js
+++ b/mikado-app/src/components/MyAppBar/MyAppBar.js
@@ -1,40 +1,34 @@
+import "./MyAppBar.css";
 import * as React from 'react';
-import { AppBar, Box, Button, Container, Toolbar, Typography } from '@mui/material'
+import { AppBar, Button, Container, Toolbar } from '@mui/material'
 import AppBarProfileOverflowMenu from "./AppBarProfileOverflowMenu";
+import SeamlessEditor from "../SeamlessEditor";
+import { useState } from "react";
 
 export default function MyAppBar({ graph, graphHandle }) {
+  const [isEditingTitle, setIsEditingTitle] = useState(false);
+  function startEditingTitle() {
+    setIsEditingTitle(true);
+  }
   return (
     <AppBar position="static">
       <Container maxWidth="x2">
-        <Toolbar disableGutters>
-          <Box
-            sx={{
-              justifyContent: 'center',
-              alignItems: 'center',
-              flexGrow: 1,
-              display: 'flex',
+        <Toolbar
+          disableGutters
+          onDoubleClick={startEditingTitle}
+          onContextMenu={startEditingTitle}
+        >
+          <SeamlessEditor
+            label={graph.id}
+            editing={isEditingTitle}
+            initialValue={graph.id}
+            onFinishEditing={(filteredText) => {
+              void filteredText; // TODO
+              setIsEditingTitle(false);
             }}
-          >
-            <Typography
-              variant="h6"
-              noWrap
-              sx={{
-                mr: 2,
-                fontFamily: 'monospace',
-                fontWeight: 700,
-                letterSpacing: '.3rem',
-                color: 'inherit',
-                textDecoration: 'none',
-              }}
-            >
-              {
-                // Placeholder for now, TODO replace with name
-              }
-              {graph.id}
-            </Typography>
-
-          </Box>
-          {(graph.subgraph !== "") && 
+            singleLine={true}
+          />
+          {(graph.subgraph !== "") &&
           <Button sx={{color: "white"}} onClick={() => {graphHandle({id: graph.id, subgraph: ""})}}>
             Back
           </Button>}

--- a/mikado-app/src/components/SeamlessEditor.js
+++ b/mikado-app/src/components/SeamlessEditor.js
@@ -1,0 +1,64 @@
+import { createElement, useEffect, useRef, useState } from "react";
+
+export default function SeamlessEditor({ label, editing, initialValue, onFinishEditing, singleLine }) {
+  const [text, setText] = useState(label);
+  const ref = useRef(void 0);
+  const wasComposingRef = useRef(false);
+  useEffect(() => {
+    if (editing) {
+      setText(initialValue);
+      ref.current?.focus();
+      ref.current?.select();
+    }
+  }, [editing]);
+  if (!singleLine) {
+    useEffect(() => {
+      const { current } = ref;
+      if (!current) return;
+      const { style } = current;
+      // Shrink and grow based on content
+      style.height = 0;
+      style.height = current.scrollHeight + "px";
+    }, [text]);
+  }
+  if (!editing && text !== label) {
+    setText(label);
+  }
+
+  function finishEditing() {
+    onFinishEditing(text.replaceAll('\n', ' '));
+  }
+
+  // <input> is single line, so <textarea> is needed
+  // <div contenteditable> is an accessibility and security problem
+  const props = {
+    autoFocus: editing,
+    className: "seamless-editor",
+    disabled: !editing,
+    value: text,
+    onChange(e) {
+      setText(e.target.value);
+    },
+    onKeyDown(e) {
+      // Don't break IMEs
+      wasComposingRef.current = e.nativeEvent.isComposing;
+    },
+    onKeyUp(e) {
+      if (e.key !== "Enter") return;
+      if (wasComposingRef.current) return;
+      finishEditing();
+    },
+    onBlur: finishEditing,
+    ref,
+  }
+  if (singleLine) {
+    props.type = "text";
+  } else {
+    props.rows = 1;
+  }
+  return createElement(singleLine ? "input" : "textarea", props);
+
+  // TODO: performance
+  // - Use HTMLInputElement over TextNode only when necessary
+  // - Find a way so that targeting a node for editing does not force all nodes to rerender. Perhaps optimize the store access a bit
+}

--- a/mikado-app/src/pages/Graph/DisplayLayer.js
+++ b/mikado-app/src/pages/Graph/DisplayLayer.js
@@ -35,7 +35,7 @@ const notifyExportError = notifyError.bind(null, "There was an error exporting t
  */
 function DisplayLayerInternal({ uid, graph }) {
   const reactFlowWrapper = useRef(void 0);
-  const { nodes, edges, operations, editNode } = useStoreHack()(selector, shallow);
+  const { nodes, edges, operations, editNode, editingNodeId } = useStoreHack()(selector, shallow);
   const { project, fitView } = useReactFlow();
   const selectedNodeId = useRef(void 0);
 
@@ -180,6 +180,8 @@ function DisplayLayerInternal({ uid, graph }) {
       edges={edges}
       onNodesChange={operations.onNodesChange}
       nodesConnectable={false}
+      nodesDraggable={!editingNodeId}
+      panOnDrag={!editingNodeId}
       proOptions={proOptions}
       defaultEdgeOptions={DEFAULT_EDGE_OPTIONS}
       nodeTypes={NODE_TYPES}

--- a/mikado-app/src/pages/Graph/NodeLabel.js
+++ b/mikado-app/src/pages/Graph/NodeLabel.js
@@ -19,6 +19,14 @@ export default function NodeLabel({ id, label }) {
       ref.current?.select();
     }
   }, [editing]);
+  useEffect(() => {
+    const { current } = ref;
+    if (!current) return;
+    const { style } = current;
+    // Shrink and grow based on content
+    style.height = 0;
+    style.height = current.scrollHeight + "px";
+  }, [text]);
   if (!editing && text !== label) {
     setText(label);
   }
@@ -28,11 +36,13 @@ export default function NodeLabel({ id, label }) {
     operations.setNodeLabel(id, filteredText);
     setText(filteredText);
   }
-  return <input
-    type="text"
+  // <input> is single link
+  // <div contenteditable> is an accessibility and security problem
+  return <textarea
     autoFocus={editing}
     disabled={!editing}
     value={text}
+    rows={1}
     onChange={(e) => {setText(e.target.value)}}
     onKeyDown={(e) => {
       // Don't break IMEs

--- a/mikado-app/src/pages/Graph/NodeLabel.js
+++ b/mikado-app/src/pages/Graph/NodeLabel.js
@@ -10,6 +10,7 @@ export default function NodeLabel({ id, label }) {
   const {editingNodeId, editingNodeInitialValue, editNode, operations} = useStoreHack()(selector);
   const [text, setText] = useState(label);
   const ref = useRef(void 0);
+  const wasComposingRef = useRef(false);
   const editing = editingNodeId === id;
   useEffect(() => {
     if (editing) {
@@ -23,7 +24,9 @@ export default function NodeLabel({ id, label }) {
   }
   function finishEditing() {
     editNode("", "");
-    operations.setNodeLabel(id, text);
+    const filteredText = text.replaceAll('\n', ' ');
+    operations.setNodeLabel(id, filteredText);
+    setText(filteredText);
   }
   return <input
     type="text"
@@ -31,8 +34,13 @@ export default function NodeLabel({ id, label }) {
     disabled={!editing}
     value={text}
     onChange={(e) => {setText(e.target.value)}}
+    onKeyDown={(e) => {
+      // Don't break IMEs
+      wasComposingRef.current = e.nativeEvent.isComposing;
+    }}
     onKeyUp={(e) => {
       if (e.key !== "Enter") return;
+      if (wasComposingRef.current) return;
       finishEditing();
     }}
     onBlur={finishEditing}

--- a/mikado-app/src/pages/Graph/NodeLabel.js
+++ b/mikado-app/src/pages/Graph/NodeLabel.js
@@ -1,5 +1,5 @@
-import { useEffect, useRef, useState } from "react";
 import { useStoreHack } from "../../StoreHackContext";
+import SeamlessEditor from "../../components/SeamlessEditor";
 
 const selector = (state) => {
   const {editingNodeId, editingNodeInitialValue, editNode, operations} = state;
@@ -8,56 +8,17 @@ const selector = (state) => {
 
 export default function NodeLabel({ id, label }) {
   const {editingNodeId, editingNodeInitialValue, editNode, operations} = useStoreHack()(selector);
-  const [text, setText] = useState(label);
-  const ref = useRef(void 0);
-  const wasComposingRef = useRef(false);
   const editing = editingNodeId === id;
-  useEffect(() => {
-    if (editing) {
-      setText(editingNodeInitialValue);
-      ref.current?.focus();
-      ref.current?.select();
-    }
-  }, [editing]);
-  useEffect(() => {
-    const { current } = ref;
-    if (!current) return;
-    const { style } = current;
-    // Shrink and grow based on content
-    style.height = 0;
-    style.height = current.scrollHeight + "px";
-  }, [text]);
-  if (!editing && text !== label) {
-    setText(label);
-  }
-  function finishEditing() {
-    editNode("", "");
-    const filteredText = text.replaceAll('\n', ' ');
-    operations.setNodeLabel(id, filteredText);
-    setText(filteredText);
-  }
   // <input> is single link
   // <div contenteditable> is an accessibility and security problem
-  return <textarea
-    autoFocus={editing}
-    disabled={!editing}
-    value={text}
-    rows={1}
-    onChange={(e) => {setText(e.target.value)}}
-    onKeyDown={(e) => {
-      // Don't break IMEs
-      wasComposingRef.current = e.nativeEvent.isComposing;
+  return <SeamlessEditor
+    label={label}
+    editing={editing}
+    initialValue={!editing ? "" : editingNodeInitialValue}
+    onFinishEditing={(filteredText) => {
+      editNode("", "");
+      operations.setNodeLabel(id, filteredText);
     }}
-    onKeyUp={(e) => {
-      if (e.key !== "Enter") return;
-      if (wasComposingRef.current) return;
-      finishEditing();
-    }}
-    onBlur={finishEditing}
-    ref={ref}
+    singleLine={false}
   />
-
-  // TODO: performance
-  // - Use HTMLInputElement over TextNode only when necessary
-  // - Find a way so that targeting a node for editing does not force all nodes to rerender. Perhaps optimize the store access a bit
 }

--- a/mikado-app/src/pages/Graph/Plaza.css
+++ b/mikado-app/src/pages/Graph/Plaza.css
@@ -45,19 +45,10 @@ main > main {
 }
 
 .react-flow__node > div {
-
-  font-family: 'Inter', sans-serif;
-  font-style: normal;
-  font-weight: 400;
-  font-size: 12px;
-  line-height: 15px;
-
   min-height: 20px; /* hugs contents */
   inline-size: 10px;
   word-break: break-all;
   padding: 2px 5px;
-
-  color: #000000;
 
   /* Inside auto layout */
 
@@ -74,7 +65,15 @@ main > main {
   top: 5px;
 }
 
-.react-flow__node textarea {
+.seamless-editor, .react-flow__node > div {
+  font-family: 'Inter', sans-serif;
+  font-style: normal;
+  font-weight: 400;
+  font-size: 12px;
+  line-height: 15px;
+}
+
+.seamless-editor {
   appearance: none;
   background: none;
   border: none;

--- a/mikado-app/src/pages/Graph/Plaza.css
+++ b/mikado-app/src/pages/Graph/Plaza.css
@@ -74,22 +74,23 @@ main > main {
   top: 5px;
 }
 
-.react-flow__node input {
+.react-flow__node textarea {
   appearance: none;
   background: none;
   border: none;
-  border-bottom: 1px solid dimgrey;
-  /* color: initial; this turns input text font grey on Apple devices, -webkit-text-fill-color is the workaround*/ 
-  -webkit-text-fill-color: rgba(0, 0, 0, 1); 
+  /* outline is all 4 sides, and border makes the element grow by 1 pixel when editing */
+  box-shadow: 0 1px 0 dimgrey;
+  /* color: initial; this turns input text font grey on Apple devices, -webkit-text-fill-color is the workaround*/
+  -webkit-text-fill-color: rgba(0, 0, 0, 1);
   color: rgba(0, 0, 0, 1);
   outline: none;
   padding: 0;
-  text-overflow: ellipsis;
+  resize: none;
   width: 100%;
 
   &:disabled {
     pointer-events: none;
-    border-bottom: none;
+    box-shadow: none;
   }
 }
 

--- a/mikado-app/src/pages/Graph/Plaza.js
+++ b/mikado-app/src/pages/Graph/Plaza.js
@@ -119,7 +119,7 @@ function Plaza({ uid }) {
   const  key = uid + graph.subgraph;
   console.debug("plaza graph", graph, "key", key);
   return <main>
-    <MyAppBar graph={graph} graphHandle={setGraph} />
+    <MyAppBar uid={uid} graph={graph} graphHandle={setGraph} />
     <DisplayLayer key={key} uid={uid}
                   graph={graph}
                   enterGraph={enterGraph}

--- a/mikado-app/src/viewmodel/serde.js
+++ b/mikado-app/src/viewmodel/serde.js
@@ -3,7 +3,7 @@ import { firebase, USING_DEBUG_EMULATORS } from '../firebase';
 import * as Counter from "./autoincrement";
 import { createEdgeObject, createNodeObject } from "./displayObjectFactory";
 
-const db = getFirestore(firebase);
+export const db = getFirestore(firebase);
 if (USING_DEBUG_EMULATORS) {
   connectFirestoreEmulator(db, "localhost", 8080);
 }


### PR DESCRIPTION
Closes #85.
Depends on #137.

The graph name is per-graph, and we decided to not include the layer name nor tie it to the goal node. Double click or long tap to edit and see it persists across refreshes.