### PR TITLE
feat: Create questline backend functionality

### DIFF
--- a/mikado-app/src/graphlayer/store/GraphLayerViewerStore.js
+++ b/mikado-app/src/graphlayer/store/GraphLayerViewerStore.js
@@ -215,21 +215,18 @@ class GraphLayerViewerOperations {
 
 	const questlineId = this.#currentQuestline.id
 
-	let canidateReadyNodes = this.#state.nodes.filter((node) => node.type == 'ready').map(function(node) {return node.id})
+	let canidateReadyNodes = this.#state.nodes.filter((node) => node.type == 'ready');
 	this.#currentTasks = [];
 
 	for (const canidateReadyNode of canidateReadyNodes) {
-		let parentNodes = this.#backwardConnections[canidateReadyNode]
-		let done = false;
+		let parentNodes = this.#backwardConnections[canidateReadyNode.id]
 		
-		while (!done) {
+		while (parentNodes.length > 0) {
 			let newParentNodes = [];
 
 			if (parentNodes.includes(questlineId.toString())) {
-				this.#currentTasks.push(...this.#state.nodes.filter((node) => node.id == canidateReadyNode))
-				done = true;
-			} else if (parentNodes.length == 0) {
-				done = true;
+				this.#currentTasks.push(canidateReadyNode)
+				break;
 			}
 
 			parentNodes.forEach((connection) => newParentNodes.push(...this.#backwardConnections[connection]))

--- a/mikado-app/src/graphlayer/store/GraphLayerViewerStore.js
+++ b/mikado-app/src/graphlayer/store/GraphLayerViewerStore.js
@@ -234,7 +234,6 @@ class GraphLayerViewerOperations {
 			parentNodes = newParentNodes;
 		}
 	}
-	console.log(this.#currentTasks);
 
   }
 

--- a/mikado-app/src/graphlayer/store/GraphLayerViewerStore.js
+++ b/mikado-app/src/graphlayer/store/GraphLayerViewerStore.js
@@ -692,6 +692,7 @@ class GraphLayerViewerOperations {
    */
   setCurrentQuestline(questlineId) {
 	this.#currentQuestline = this.#questParents.filter((node) => node.id == questlineId);
+	this.updateQuestParents();
   }
 
   /**

--- a/mikado-app/src/helpers/Api.js
+++ b/mikado-app/src/helpers/Api.js
@@ -21,7 +21,6 @@ export async function loadFromDb(uid, graphName, subgraphName) {
 
   // TODO add a version key and prevent loading newer schemas
   const { node_names, positions, connections, type } = docSnap.data();
-  console.log(docSnap.data());
 
   /**
    * Lookup table so that newEdges can follow the remapped ids in newNodes.


### PR DESCRIPTION
+ Quests are now loaded upon graph load and updates with certain actions (connect/disconnect, graph loading, node completion)
+ Tasks are chosen based on current questline (ready, is apart of questline), and can be shared across quests
+ Available getters and setters:
-> getCurrentTasks(): gets current task list for current questline
-> getCurrentQuestline(): gets current questline parent node
-> setCurrentQuestline(): sets questline by id and updates currentTasks
-> getAllQuests(): gets all avalable questlines
