### PR TITLE
fix: Mobile zoom of wrong element

### DIFF
--- a/mikado-app/src/pages/Graph/GraphViewer.css
+++ b/mikado-app/src/pages/Graph/GraphViewer.css
@@ -10,6 +10,7 @@
   width: 100%;
   display: flex;
   flex-direction: column;
+  touch-action: manipulation;
 }
 
 .react-flow__edge-path {


### PR DESCRIPTION
Attempts to fix the double tap on iOS. The graph viewport needs to be zoomed, not the document viewport.